### PR TITLE
Lowered mock cfclient max retries to 10

### DIFF
--- a/mock/cf_client.go
+++ b/mock/cf_client.go
@@ -17,7 +17,7 @@ const (
 	spaceGUID = "sector-42-a-19"
 )
 
-var MaxGetTaskRetries = 30
+var MaxGetTaskRetries = 10
 
 var spaceManager = cf.V3Role{
 	GUID: "j4m3s-t-k1rk",


### PR DESCRIPTION
This way, when we demo things, things finish in a reasonable
amount of time.