### PR TITLE
Fix the order of the Calls fields in the postgres service

### DIFF
--- a/postgres/call_service.go
+++ b/postgres/call_service.go
@@ -123,7 +123,7 @@ func (service *CallService) getCollection(query string, args ...interface{}) []*
 		var createdAt time.Time
 		var updatedAt time.Time
 
-		err := rows.Scan(&guid, &name, &url, &authHeader, &spaceGUID, &appGUID, &createdAt, &updatedAt)
+		err := rows.Scan(&guid, &name, &url, &authHeader, &appGUID, &spaceGUID, &createdAt, &updatedAt)
 		if err != nil {
 			continue
 		}
@@ -133,8 +133,8 @@ func (service *CallService) getCollection(query string, args ...interface{}) []*
 			Name:       name,
 			URL:        url,
 			AuthHeader: authHeader,
-			SpaceGUID:  spaceGUID,
 			AppGUID:    appGUID,
+			SpaceGUID:  spaceGUID,
 			CreatedAt:  createdAt,
 			UpdatedAt:  updatedAt,
 		}


### PR DESCRIPTION
To make a long story short, we record call.AppGUID, then
call.SpaceGUID. We were reading spaceGUID, then appGUID.

The read function has now been aligned with the write function.

Fixes #56 