### PR TITLE
Switch GET to POST in HTTP run service

### DIFF
--- a/http/run_service.go
+++ b/http/run_service.go
@@ -43,12 +43,12 @@ func (service *RunService) Execute(services *core.Services, execution *core.Exec
 		} else {
 
 			response := driver.
-				Get("", nil).
+				Post("", nil, nil).
 				WithHeaderSet(hype.NewHeader("Authorization", call.AuthHeader)).
 				Response()
 
 			if response.Okay() {
-				services.Executions.UpdateMessage(execution, "GET success")
+				services.Executions.UpdateMessage(execution, "POST success")
 				services.Executions.Success(execution)
 			} else {
 				services.Executions.UpdateMessage(execution, response.Error().Error())


### PR DESCRIPTION
scheduler-for-pcf executes calls as POST request, not as GET
requests. To that end, we are now issuing POST requests with
empty data blobs.

Fixes #58 